### PR TITLE
fix NaN angles

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -231,6 +231,7 @@ function Makie.plot!(gp::GraphPlot)
     to_angle = @lift (path, p0, t) -> begin
         # TODO: maybe shorter tangent? For some perspectives this might give wrong angles in 3d
         p1 = p0 + tangent(path, t)
+        any(isnan, p1) && return 0.0  # lines with zero lengths might lead to NaN tangents
         tpx = $to_px(p1) - $to_px(p0)
         atan(tpx[2], tpx[1])
     end


### PR DESCRIPTION
To place arrowheads on lines we need to calculate their direction. If lines have no length, this leads to NaN. But scatter plot with `Billboard(NaN)` breaks Makie spectacularly.

See https://github.com/JuliaGraphs/NetworkLayout.jl/issues/66