### PR TITLE
Fixed broken link to NetworkLayouts.jl in function documentation

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -27,7 +27,7 @@ underlying graph and therefore changing the number of Edges/Nodes.
 
 ## Attributes
 ### Main attributes
-- `layout=Spring()`: function `AbstractGraph->Vector{Point}` or `Vector{Point}` that determines the base layout.  Can also be any network layout from [NetworkLayout.jl](https://https://github.com/JuliaGraphs/NetworkLayout.jl), like `Spring`, `Stress`, `Spectral`, etc.
+- `layout=Spring()`: function `AbstractGraph->Vector{Point}` or `Vector{Point}` that determines the base layout.  Can also be any network layout from [NetworkLayout.jl](https://github.com/JuliaGraphs/NetworkLayout.jl), like `Spring`, `Stress`, `Spectral`, etc.
 - `node_color=automatic`:
   Defaults to `scatter_theme.color` in absence of `ilabels`.
 - `node_size=automatic`:


### PR DESCRIPTION
"https://" appeared twice in the link, making it direct to the wrong page.